### PR TITLE
Push pc_remove, select_samples, zero_imputation + test

### DIFF
--- a/R/pc_remove.R
+++ b/R/pc_remove.R
@@ -67,13 +67,12 @@ pc_remove <- function(mat,
 
   # Decide how many PCs to remove:
   choose_k <- function(Y) {
-    # Y is samples x genes - transpose
     if (identical(n_pcs, "auto")) {
       if (!requireNamespace("sva", quietly = TRUE)) {
         stop("Install 'sva' for n_pcs='auto'.")
       }
-      mod <- matrix(1, nrow = nrow(Y), ncol = 1)
-      k   <- as.integer(sva::num.sv(t(Y), mod, method = "be"))
+      mod <- matrix(1, nrow = ncol(Y), ncol = 1)
+      k   <- as.integer(sva::num.sv(Y, mod, method = "be"))
     } else {
       k <- as.integer(n_pcs)
     }
@@ -94,19 +93,19 @@ pc_remove <- function(mat,
       return(list(corrected = block, k = 0L, dropped = rownames(block)[!kept_idx]))
     }
 
-    # 2) transpose: samples x genes
-    Y <- t(M)
-
-    # 3) pick k
-    k <- choose_k(Y)
+    # 2) pick k
+    k <- choose_k(M)
     cat("   PCs to remove:", k, "\n")
+
+    # 3) transpose: samples x genes
+    Y <- t(M)
 
     # 4) regress out top k PCs
     if (k > 0) {
       sv  <- svd(Y, nu = k, nv = 0)               # only need U (left singular vectors)
       U   <- sv$u[, seq_len(k), drop = FALSE]
       X   <- cbind(1, U)                          # design = [Intercept, U_k]
-      beta <- solve(crossprod(X), crossprod(X, Y))
+      beta <- solve(crossprod(X), crossprod(X, Y)) # least squares solution
       Y_adj <- Y - X %*% beta                     # residuals
     } else {
       # no PCs: no change

--- a/R/pc_remove.R
+++ b/R/pc_remove.R
@@ -82,7 +82,7 @@ pc_remove <- function(mat,
   }
 
   # Correct one block (either the whole matrix, or one study subset)
-  correct_block <- function(block, label = NULL) {
+  correct_block <- function(block) {
 
     # 1) drop ~zero-variance genes
     dz <- drop_zero_var(block)
@@ -125,7 +125,7 @@ pc_remove <- function(mat,
   dropped_all   <- character(0)
 
   if (method == "global") {
-    g <- correct_block(mat, "GLOBAL")
+    g <- correct_block(mat)
     mat_pc <- g$corrected
     n_out   <- g$k
     dropped_all <- g$dropped
@@ -153,7 +153,7 @@ pc_remove <- function(mat,
         blocks[[s]] <- sub
         meta$n_pcs[meta$Study == s] <- 0L
       } else {
-        res <- correct_block(sub, s)
+        res <- correct_block(sub)
         blocks[[s]] <- res$corrected
         meta$n_pcs[meta$Study == s] <- res$k
         dropped_all <- c(dropped_all, res$dropped)

--- a/R/select_samples.R
+++ b/R/select_samples.R
@@ -4,12 +4,14 @@
 #' 1) Inputs are genes by samples
 #' 2) Both RNA and Ribo are calculated for same set of samples
 #' 3) The data represents read counts and is not cpm/clr normalized.
+#' 4) The Ribo and RNA matrices have undergone zero imputation.
 #'
 #' Existing features
-#' a) Support removing samples where dummy genes is a large proportion of the remaining
+#' a) Support removing samples where dummy genes are a large proportion of the
+#' remaining counts
 #' b) Support removing samples with poor correspondence between RNA and Ribo
-#' this is currently done after adding one count to all values to avoid zeros
-#' then each is clr normalized and r2 from lm(RIBO~RNA) is used for selecting samples to remove
+#' Samples are selected for removal based on r^2 from lm(RIBO~RNA) after
+#' CLR-normalization
 #'
 #' Optional features to Implement later
 #' a) Support only ribo or RNA
@@ -80,6 +82,14 @@ select_samples <- function(RIBO, RNA,
     stop("RIBO and RNA must share identical sample columns")
   }
 
+  if (!identical(rownames(RIBO), rownames(RNA))) {
+    stop("RIBO and RNA must share identical gene rows")
+  }
+
+  if(0 %in% RIBO || 0 %in% RNA) {
+    stop("Ribo/RNA matrices contain zeroes. Please impute.")
+  }
+
   # Early exit if no filtering requested
   if (high_dummy_percentage == 0 && min_r2 == 0 && min_periodicity == 0) {
     return(list(ribo = RIBO, rna = RNA))
@@ -127,14 +137,13 @@ select_samples <- function(RIBO, RNA,
     keep_periodicity <- sample_periodicity >= min_periodicity
     if (any(!keep_periodicity)) {
       current_ribo <- current_ribo[, keep_periodicity, drop = FALSE]
-      current_rna  <- current_rna [, keep_periodicity, drop = FALSE]
+      current_rna  <- current_rna[, keep_periodicity, drop = FALSE]
     }
   }
 
   if (min_r2 > 0 && ncol(current_ribo) > 0) {
-    imputed <- zero_imputation(current_ribo, current_rna)
-    ribo_clr <- t(compositions::clr(t(imputed$ribo)))
-    rna_clr  <- t(compositions::clr(t(imputed$rna)))
+    ribo_clr <- t(compositions::clr(t(current_ribo)))
+    rna_clr <- t(compositions::clr(t(current_rna)))
 
     sample_r2 <- vapply(seq_len(ncol(ribo_clr)), function(i) {
       fit <- stats::lm(ribo_clr[, i] ~ rna_clr[, i])

--- a/R/zero_imputation.R
+++ b/R/zero_imputation.R
@@ -2,15 +2,17 @@
 #'
 #' Many compositional workflows require strictly positive counts before
 #' applying log-ratio transforms. This utility either performs a simple
-#' zero-imputation step (replace zeros with ones) or a multiplicative
-#' replacement using `zCompositions::cmultRepl()`.
+#' zero-imputation step (replace zeros with the minimum non-zero value) or
+#' a multiplicative replacement using `zCompositions::cmultRepl()`.
 #'
 #' @param RIBO numeric matrix or data.frame of counts with genes in rows and
 #'   samples in columns.
 #' @param RNA numeric matrix or data.frame of counts with genes in rows and
 #'   samples in columns.
-#' @param method imputation strategy to use. `"simple"` replaces zeros with ones,
-#'   `"multiplicative"` delegates to `zCompositions::cmultRepl()`.
+#' @param method imputation strategy to use.
+#'   - `"simple"` replaces zeros with either the matrix minimum value if it's <1
+#'       or 1
+#'   - `"multiplicative"` delegates to `zCompositions::cmultRepl()`.
 #' @param multiplicative_method method argument passed to
 #'   `zCompositions::cmultRepl()` when `method = "multiplicative"`.
 #' @param output output argument passed to `zCompositions::cmultRepl()` when
@@ -22,6 +24,9 @@
 #' @return list with elements
 #'   - ribo: `RIBO` converted to a matrix with imputed values.
 #'   - rna:  `RNA` converted to a matrix with imputed values.
+#'
+#' Samples or genes removed internally during `cmultRepl()` are realigned by
+#' keeping the common rows and columns between the imputed RIBO and RNA matrices.
 #'
 #' @examples
 #' RIBO <- matrix(c(0, 5, 10,
@@ -50,8 +55,12 @@ zero_imputation <- function(
   rna_mat  <- as.matrix(RNA)
 
   if (method == "simple") {
-    ribo_mat[ribo_mat == 0] <- 1
-    rna_mat [rna_mat  == 0] <- 1
+    ribo_min <- min(min(ribo_mat[ribo_mat > 0]), 1)
+    rna_min <- min(min(rna_mat[rna_mat > 0]), 1)
+
+    ribo_mat[ribo_mat == 0] <- ribo_min
+    rna_mat[rna_mat == 0] <- rna_min
+
   } else {
     impute_multiplicative <- function(mat) {
       target <- if (transpose) t(mat) else mat
@@ -69,6 +78,12 @@ zero_imputation <- function(
     ribo_mat <- impute_multiplicative(ribo_mat)
     rna_mat  <- impute_multiplicative(rna_mat)
   }
+
+  common_genes   <- intersect(rownames(ribo_mat), rownames(rna_mat))
+  common_samples <- intersect(colnames(ribo_mat), colnames(rna_mat))
+
+  ribo_mat <- ribo_mat[common_genes, common_samples, drop = FALSE]
+  rna_mat  <- rna_mat[common_genes, common_samples, drop = FALSE]
 
   list(
     ribo = ribo_mat,

--- a/tests/testthat/test-zero_imputation.R
+++ b/tests/testthat/test-zero_imputation.R
@@ -9,7 +9,7 @@ test_that("zero_imputation replaces zeros with ones", {
   )
   RNA <- matrix(
     c(7, 8, 9,
-      0, 0, 3),
+      0, 0.1, 3),
     nrow = 2, byrow = T,
     dimnames = list(c("g1", "g2"), paste0("s", 1:3))
   )
@@ -17,11 +17,11 @@ test_that("zero_imputation replaces zeros with ones", {
   res <- zero_imputation(RIBO, RNA)
 
   expect_true(all(res$ribo >= 1))
-  expect_true(all(res$rna  >= 1))
+  expect_true(all(res$rna  > 0))
   expect_equal(res$ribo[1, 1], 1)
   expect_equal(res$ribo[1, 3], 1)
-  expect_equal(res$rna [2, 1], 1)
-  expect_equal(res$rna [2, 2], 1)
+  expect_equal(res$rna [2, 1], 0.1)
+  expect_equal(res$rna [2, 2], 0.1)
 })
 
 test_that("zero_imputation preserves non-zero values and structure", {

--- a/tests/testthat/test-zero_imputation.R
+++ b/tests/testthat/test-zero_imputation.R
@@ -77,3 +77,35 @@ test_that("multiplicative imputation delegates to zCompositions", {
   expect_true(all(res$ribo > 0))
   expect_true(all(res$rna  > 0))
 })
+
+test_that("simple zero_imputation caps replacement at 1 when minimum non-zero value is greater than 1", {
+  RIBO <- matrix(
+    c(0, 2, 5,
+      3, 4, 6),
+    nrow = 2, byrow = TRUE,
+    dimnames = list(c("g1", "g2"), paste0("s", 1:3))
+  )
+  RNA <- matrix(
+    c(7, 0, 8,
+      2, 3, 4),
+    nrow = 2, byrow = TRUE,
+    dimnames = list(c("g1", "g2"), paste0("s", 1:3))
+  )
+
+  res <- zero_imputation(RIBO, RNA)
+
+  # Smallest non-zero values are > 1, so zeros should still become 1
+  expect_equal(res$ribo["g1", "s1"], 1)
+  expect_equal(res$rna["g1", "s2"], 1)
+
+  # Non-zero values should stay unchanged
+  expect_equal(res$ribo["g1", "s2"], 2)
+  expect_equal(res$ribo["g2", "s3"], 6)
+  expect_equal(res$rna["g2", "s1"], 2)
+  expect_equal(res$rna["g1", "s3"], 8)
+
+  # Everything should be positive after imputation
+  expect_true(all(res$ribo > 0))
+  expect_true(all(res$rna > 0))
+})
+#


### PR DESCRIPTION
- `pc_remove`: clean up redundant transpose/reordering steps
- `select_samples`: require zero-imputed inputs instead of handling zero imputation internally
- `zero_imputation`: update simple imputation to replace zeros with the minimum non-zero value, capped at 1; intersect RIBO and RNA matrices at the end to account for dropped samples
- `test-zero_imputation`: update tests for the new simple-imputation behavior and add a test for the cap-at-1 case